### PR TITLE
DLC load clarification ESL

### DIFF
--- a/_ark/ui/locale/esl/locale_updates_keep.dta
+++ b/_ark/ui/locale/esl/locale_updates_keep.dta
@@ -221,6 +221,8 @@
 (mod_chmode_desc "Aumenta drásticamente la ventana de aciertos")
 (mod_chord_numbers "Numerar acordes")
 (mod_chord_numbers_desc "Muestra los números de trastes individuales de un acorde en Guitarra/Bajo Pro")
+(mod_kick_bounce "Rebote de Bombo")
+(mod_kick_bounce_desc "La pista rebota al tocar el bombo")
 (mod_doublespeed "Velocidad Suicida")
 (mod_drum_fills_desc "Utiliza el modo Freestyle de la batería para activar la Sobrecarga")
 (mod_drum_surface_navigation_desc "Navega los menús con los pads de la batería")
@@ -735,6 +737,9 @@
 (os_trackconfig_desc "Controla el punto de vista de la pista")
 (os_track_hud "HUD de Pista")
 (os_track_hud_desc "Controla elementos específicos de la HUD de la pista")
+(os_track_lengths "Longitud de Pista")
+(dx_track_lengths_desc "Modifica la longitud de las pistas") ; This is here until English is fixed
+(os_track_lengths_desc "Modifica la longitud de las pistas")
 (os_tweaks "Ajustes")
 (os_tweaks_desc "Varios ajustes a elementos tanto dentro como alrededor del juego")
 (os_vertical "Vertical")

--- a/_ark/ui/locale/esl/locale_updates_keep.dta
+++ b/_ark/ui/locale/esl/locale_updates_keep.dta
@@ -1418,7 +1418,7 @@
 (loading_additional_content "Cargando temas descargados...")
 #ifdef HX_PS3
 (loading_additional_content
-   "Cargando contenido descargado...")
+   "Cargando contenido...")
 #endif
 (loading_additional_progress
    "%s/%s cargado")

--- a/_ark/ui/locale/esl/locale_updates_keep.dta
+++ b/_ark/ui/locale/esl/locale_updates_keep.dta
@@ -1416,6 +1416,12 @@
 (confirm_quit_online "Perderás todo el progreso no guardado si continúas. ¿Estás seguro?")
 (connecting_server "Conectándose a los servidores del juego...")
 (loading_additional_content "Cargando temas descargados...")
+#ifdef HX_PS3
+(loading_additional_content
+   "Cargando contenido descargado...")
+#endif
+(loading_additional_progress
+   "%s/%s cargado")
 (country "Country")
 (create_char_gender "Cuerpo")
 (delete_song "Borrar Paquete De Temas")


### PR DESCRIPTION
Originally, my idea was to change this to say `%s/%s paquetes cargado` (`%s/%s packs loaded`) but apparently this would cause confusion (???)
I originally wanted to translate Linos' but, according to Alo, "normal people don't see it that way" and that this change would be confusing. I mentioned that every song is technically a package and that packages can install a single song or a lot more but, again, normal users don't see it this way.

We almost used "DLC Loaded" but ultimately, `%s/%s loaded` won out in the end since it's close to RB4. I would personally still prefer "packs" because that's how Deluxe also renamed the "Delete Song" menu but alas, democracy.