### PR TITLE
fix lyric display appearing on certain no vox songs

### DIFF
--- a/_ark/dx/track/hud_ui/dx_hud_ui_funcs.dta
+++ b/_ark/dx/track/hud_ui/dx_hud_ui_funcs.dta
@@ -928,7 +928,7 @@
    {lyric_upcoming.lbl set_token_fmt {sprint ""}}
    {lyric_fadingout.lbl set_token_fmt {sprint ""}}
 
-   {if_else {&& $dx_lyric_display_enabled {! {gamemode in_mode practice}} {!= {song_mgr num_vocal_parts {meta_performer song}} 0} {|| {! $lyrics_player_active} $dx_debug_force_lyric_display}}
+   {if_else {&& $dx_lyric_display_enabled {! {gamemode in_mode practice}} {!= {song_mgr num_vocal_parts {meta_performer song}} 0} {|| {! $lyrics_player_active} $dx_debug_force_lyric_display} $dx_lyric_display_phrases}
       {do
          {set $lyrics_out TRUE}
          {dx_lyric_display_advance_phrase}

--- a/_ark/dx/track/track/dx_track_panel_handles.dta
+++ b/_ark/dx/track/track/dx_track_panel_handles.dta
@@ -1,6 +1,7 @@
 #define DX_TRACK_PANEL_HANDLES
 (
    (dx_track_panel_exit ;this is really stupid but debug found out that the textures need to be put back to origin, deleted, and remade per enter
+      {set $dx_lyric_display_phrases kDataUnhandled}
       {unless {$this get dx_is_nohud}
          {{coop_track_panel find fcframe.tex} iterate_refs $ref {$ref set diffuse_tex streak_meter_plate.tex}} ;apply the fc texture to the ring material
          {{coop_track_panel find multframe.tex} iterate_refs $ref {$ref set diffuse_tex streak_meter_plate.tex}} ;apply the fc texture to the ring material


### PR DESCRIPTION
`{song_mgr num_vocal_parts {meta_performer song}}` reports 1 on certain no vox songs for some mysterious reason so we rely on whether or not the midi parser for lyrics ran