### PR TITLE
Add additional Harmonix sources

### DIFF
--- a/_ark/dx/locale/dx_locale_sources.dta
+++ b/_ark/dx/locale/dx_locale_sources.dta
@@ -46,11 +46,23 @@
 (ghdlc "Guitar Hero Series DLC")
 
 ; Harmonix games
+(acs "A City Sleeps")
+(amp03 "Amplitude (2003)")
+(amp16 "Amplitude (2016)")
+(antigrav "EyeToy: Antigrav")
+(audica "Audica")
 (flux "Fantasia")
 (fnfestival "Fortnite Festival")
+(freq "Frequency")
 (ham1 "Dance Central")
 (ham2 "Dance Central 2")
 (ham3 "Dance Central 3")
+(kr_cmt "CMT Presents: Karaoke Revolution Country")
+(kr_party "Karaoke Revolution Party")
+(kr_vol_1 "Karaoke Revolution (2003)")
+(kr_vol_2 "Karaoke Revolution Vol. 2")
+(kr_vol_3 "Karaoke Revolution Vol. 3")
+(kr "Karaoke Revolution Series")
 (viper "Dance Central Spotlight")
 
 ; Rock Band games


### PR DESCRIPTION
Dance Central and Fantasia get sources, but not Amplitude?

Dropmix and Fuser were intentionally left out, as their loops were not full songs and full-sized mixes of them seem to be making their way into setups under a different source already covered by locale.