### PR TITLE
Fixes for most (if not all) cases of INVALID judgments

### DIFF
--- a/_ark/dx/game/dx_game_handles.dta
+++ b/_ark/dx/game/dx_game_handles.dta
@@ -10,6 +10,12 @@
                      {if {! {modifier_mgr is_modifier_active mod_auto_play}}
                         {$player set_auto_play FALSE}
                      }
+                     {if {!= {int {eval {var {sprint {$player instrument} "_note_tracker_2_size"}}}} {int {$player get_gem_count}} }
+                        {dx_log_writer countdown {sprint "--------------------------------------------------------------------------------------------------------------------------"}}
+                        {dx_log_writer countdown {sprint "WARNING: Current song (" {{song_mgr get_meta_data {meta_performer song}} title} ") has invalid " {$player instrument} " judgments!"}}
+                        {dx_log_writer countdown {sprint "NT2 size: " {eval {var {sprint {$player instrument} "_note_tracker_2_size"}}} " GGC size: " {$player get_gem_count}}}
+                        {dx_log_writer countdown {sprint "--------------------------------------------------------------------------------------------------------------------------"}}
+                     }
                   }
                }
                {dx_set_auto_play}

--- a/_ark/dx/read_write/dx_reader_macros.dta
+++ b/_ark/dx/read_write/dx_reader_macros.dta
@@ -148,6 +148,11 @@
          {elem {find $entry debug_mode} 1}
       }
    }
+   {if {== {elem $entry 0} {basename dx_judgment_dbg}}
+      {set $dx_judgment_dbg
+         {elem {find $entry dx_judgment_dbg} 1}
+      }
+   }
    {if {== {elem $entry 0} {basename dx_admin_mode}}
       {set $dx_admin_mode
          {elem {find $entry dx_admin_mode} 1}

--- a/_ark/dx/read_write/dx_writer_macros.dta
+++ b/_ark/dx/read_write/dx_writer_macros.dta
@@ -1,6 +1,7 @@
 #define DX_SETTINGS_POPULATION
 (
 	{dx_setting_saver dx_settings debug_mode $dx_debug}
+   {dx_setting_saver dx_settings dx_judgment_dbg $dx_judgment_dbg}
    {dx_setting_saver dx_settings dx_admin_mode $dx_admin_mode}
    {dx_setting_saver dx_settings selected_track_theme $dx_track_theme_name}
    {dx_setting_saver dx_settings tracked_themes $dx_tracked_track_themes}

--- a/_ark/dx/track/callbacks/dx_track_callbacks.dta
+++ b/_ark/dx/track/callbacks/dx_track_callbacks.dta
@@ -42,6 +42,7 @@
       (curr_ms 0)
       (diff none)
       (gem_id 0)
+      (total_notes 0)
       (hit ;when a note is hit
          ($gem_id)
          ;store gem_id as fast as possible
@@ -55,10 +56,12 @@
                   {set [curr_ms] {'-' {beatmatch get_song_ms} {int {floor {'+' 0.5 {profile_mgr get_excess_audio_lag}}}}}}
                   {set [offset] FALSE}
                   {set [accuracy] -8675309}
+                  ;[note_time] is also used in a commented debug line
+                  {set [note_time] {elem {eval {var {sprint [track_instrument] "_note_tracker_2"}}} [gem_id]}}
                   ;failsafe, ensure the size of our tracker is the same as the reported total note count
-                  {if {== {eval {var {sprint [track_instrument] "_note_tracker_2_size"}}} {[player] get_gem_count}}
+                  {if {== [total_notes] {[player] get_gem_count}}
                      {if {>= [gem_id] 0}
-                        {set [accuracy] {'-' [curr_ms] {elem {eval {var {sprint [track_instrument] "_note_tracker_2"}}} [gem_id]}}}
+                        {set [accuracy] {'-' [curr_ms] [note_time]}}
                      }
                   }
                   {$this perfects_indicator [accuracy]}
@@ -108,7 +111,7 @@
       (timing 0)
       (accuracy 0)
       (negative 0)
-      (total 0)
+      (total_offset 0)
       (perfects 0)
       (perfects_indicator
          ($accuracy)
@@ -116,6 +119,15 @@
             {if_else {> {+ [num_gems_miss] [num_gems_hit] [num_gems_pass]} 10}
                {dx_perfect_hit $dx_perfects_indicator [track_instrument] [player] [slot] $dx_detailed_hit_stats [timing] hide}
                {dx_perfect_hit $dx_perfects_indicator [track_instrument] [player] [slot] $dx_detailed_hit_stats [timing] invalid}
+            }
+            {if $dx_judgment_dbg
+               {{coop_track_panel find tracker_broadcast_display} set_showing TRUE}
+               {{{coop_track_panel find tracker_broadcast_display} find band_message.lbl} set_showing TRUE}
+               {{coop_track_panel find tracker_broadcast_display} set_challenge_type kTrackerChallengeType_Streak}
+               {{coop_track_panel find tracker_broadcast_display} set_display_type kBroadcastTrackerDisplay_BandMessage}
+               {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint $sprinting}}}
+               {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "Total notes in tracker: " [total_notes] " GetGemCount: " {[player] get_gem_count} " GemID: " [gem_id]}}}
+               ;{{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "GemID: " [gem_id] " GemID time: " [note_time] " Hit time: " [curr_ms]}}}
             }
          }
          {if {!= $accuracy -8675309}
@@ -167,7 +179,7 @@
                ;      {{{{{coop_track_panel find gem_track_resources} find smasher_plate_guitar} find gem_smasher0} find stop_burn.trig} trigger}
                ;   )
                ;}
-               {set [total] {+ [total] [offset]}}
+               {set [total_offset] {+ [total_offset] [offset]}}
                ;debug, show values
                {if $dx_judgment_dbg
                   {{coop_track_panel find tracker_broadcast_display} set_showing TRUE}
@@ -189,6 +201,7 @@
    {{sprint "fc_" $instrument "_callback"} set player $player}
    {{sprint "fc_" $instrument "_callback"} set slot $slot}
    {{sprint "fc_" $instrument "_callback"} set diff {{$player get_user} get_difficulty_sym}}
+   {{sprint "fc_" $instrument "_callback"} set total_notes {eval {var {sprint $instrument "_note_tracker_2_size"}}}}
 }
 {new Object dx_streak_callback
    (hit {$this update_streak})

--- a/_ark/dx/track/callbacks/dx_track_callbacks.dta
+++ b/_ark/dx/track/callbacks/dx_track_callbacks.dta
@@ -187,7 +187,8 @@
                   {{coop_track_panel find tracker_broadcast_display} set_challenge_type kTrackerChallengeType_Streak}
                   {{coop_track_panel find tracker_broadcast_display} set_display_type kBroadcastTrackerDisplay_BandMessage}
                   {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint $sprinting}}}
-                  {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "Accuracy: " {- [offset] $dx_window_offset} " Avg: " {- {/ [total] [num_gems_hit]} $dx_window_offset}}}}
+                  {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "Accuracy: " {- [offset] $dx_window_offset} " Avg: " {- {/ [total_offset] [num_gems_hit]} $dx_window_offset}}}}
+                  ;{{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "Note time (ms): " [note_time] "\nHit time: " [curr_ms]}}}
                }
             }
          }

--- a/_ark/dx/track/callbacks/dx_track_callbacks.dta
+++ b/_ark/dx/track/callbacks/dx_track_callbacks.dta
@@ -46,7 +46,7 @@
       (hit ;when a note is hit
          ($gem_id)
          ;store gem_id as fast as possible
-         {set [gem_id] $gem_id}
+         {set [gem_id] $gem_id} ;0-indexed
          {if {exists {sprint "perfect_task_" [track_instrument]}} {delete {sprint "perfect_task_" [track_instrument]}}}
          {thread_task kTaskBeats
             (name {sprint "perfect_task_" [track_instrument]})
@@ -187,7 +187,7 @@
                   {{coop_track_panel find tracker_broadcast_display} set_challenge_type kTrackerChallengeType_Streak}
                   {{coop_track_panel find tracker_broadcast_display} set_display_type kBroadcastTrackerDisplay_BandMessage}
                   {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint $sprinting}}}
-                  {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "Accuracy: " {- [offset] $dx_window_offset} " Avg: " {- {/ [total_offset] [num_gems_hit]} $dx_window_offset}}}}
+                  {{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "Accuracy: " {- [offset] $dx_window_offset} "\nAvg: " {- {/ [total_offset] [num_gems_hit]} $dx_window_offset}}}}
                   ;{{coop_track_panel find tracker_broadcast_display} show_brief_band_message {symbol {sprint "Note time (ms): " [note_time] "\nHit time: " [curr_ms]}}}
                }
             }

--- a/_ark/dx/track/countdown/dx_countdown_midi_parsers.dta
+++ b/_ark/dx/track/countdown/dx_countdown_midi_parsers.dta
@@ -10,14 +10,14 @@
    (mp.up FALSE)
    (idle)
    (allowed_notes
-      (96 97 98 99 100 103 120)
+      (96 97 98 99 100 103 120) ;103 = solo, 120 = lowest of BRE
    )
    (midi
       {unless $first_guitar_gem_tracked
          {set $first_guitar_gem_tracked TRUE}
          {set $tracked_break_num_guitar 0}
          {set $first_guitar_gem_beat {int $mp.start}}
-         {set $mp.endcache 0} ; cache note end time
+         {set $dx_last_note_ended_guitar 0} ; cache note end time
          {if {> $first_guitar_gem_beat 16}
             {push_back $guitar_note_tracker ("delay_0" 0 $first_guitar_gem_beat)}
             {set $guitar_note_tracker {array $guitar_note_tracker}}
@@ -35,13 +35,14 @@
       {if {> $dx_final_note_guitar $dx_final_note} {set $dx_final_note $dx_final_note_guitar}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
-            {if {>= {- $mp.start $mp.endcache} 0}
+            {if {>= {- $mp.start $dx_last_note_ended_guitar} 0}
                {push_back $guitar_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $guitar_note_tracker_2_size {size $guitar_note_tracker_2}}
-               {set $mp.endcache $mp.end} ; cache note end time
+               {set $dx_last_note_ended_guitar $mp.end} ; cache note end time
             }
          }
       }
+      
    )
 }
 {new
@@ -100,7 +101,7 @@
       {unless $first_real_guitar_gem_tracked
          {set $first_real_guitar_gem_tracked TRUE}
          {set $tracked_break_num_real_guitar 0}
-         {set $mp.endcache 0} ; cache note end time
+         {set $dx_last_note_ended_real_guitar 0} ; cache note end time
          {set $first_real_guitar_gem_beat {int $mp.start}}
          {if {> $first_real_guitar_gem_beat 16}
             {push_back $real_guitar_note_tracker ("delay_0" 0 $first_real_guitar_gem_beat)}
@@ -119,10 +120,10 @@
       {if {> $dx_final_note_real_guitar $dx_final_note} {set $dx_final_note $dx_final_note_real_guitar}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100} {== $mp.val 101}}
-            {if {>= {- $mp.start $mp.endcache} 0}
+            {if {>= {- $mp.start $dx_last_note_ended_real_guitar} 0}
                {push_back $real_guitar_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $real_guitar_note_tracker_2_size {size $real_guitar_note_tracker_2}}
-               {set $mp.endcache $mp.end} ; cache note end time
+               {set $dx_last_note_ended_real_guitar $mp.end} ; cache note end time
             }
          }
       }
@@ -230,7 +231,7 @@
       {set $dx_final_note_drum {int $mp.end}}
       {if {> $dx_final_note_drum $dx_final_note} {set $dx_final_note $dx_final_note_drum}}
       {if $dx_perfects_indicator
-         {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
+         {if {|| {== $mp.val 95} {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
             {push_back $drum_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
             {set $drum_note_tracker_2_size {size $drum_note_tracker_2}}
          }
@@ -297,7 +298,7 @@
       {unless $first_bass_gem_tracked
          {set $first_bass_gem_tracked TRUE}
          {set $tracked_break_num_bass 0}
-         {set $mp.endcache 0} ; cache note end time
+         {set $dx_last_note_ended_bass 0} ; cache note end time
          {set $first_bass_gem_beat {int $mp.start}}
          {if {> $first_bass_gem_beat 16}
             {push_back $bass_note_tracker ("delay_0" 0 $first_bass_gem_beat)}
@@ -316,10 +317,10 @@
       {if {> $dx_final_note_bass $dx_final_note} {set $dx_final_note $dx_final_note_bass}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
-            {if {>= {- $mp.start $mp.endcache} 0}
+            {if {>= {- $mp.start $dx_last_note_ended_bass} 0}
                {push_back $bass_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $bass_note_tracker_2_size {size $bass_note_tracker_2}}
-               {set $mp.endcache $mp.end} ; cache note end time
+               {set $dx_last_note_ended_bass $mp.end} ; cache note end time
             }
          }
       }
@@ -381,7 +382,7 @@
       {unless $first_real_bass_gem_tracked
          {set $first_real_bass_gem_tracked TRUE}
          {set $tracked_break_num_real_bass 0}
-         {set $mp.endcache 0} ; cache note end time
+         {set $dx_last_note_ended_real_bass 0} ; cache note end time
          {set $first_real_bass_gem_beat {int $mp.start}}
          {if {> $first_real_bass_gem_beat 16}
             {push_back $real_bass_note_tracker ("delay_0" 0 $first_real_bass_gem_beat)}
@@ -400,10 +401,10 @@
       {if {> $dx_final_note_real_bass $dx_final_note} {set $dx_final_note $dx_final_note_real_bass}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100} {== $mp.val 101}}
-            {if {>= {- $mp.start $mp.endcache} 0}
+            {if {>= {- $mp.start $dx_last_note_ended_real_bass} 0}
                {push_back $real_bass_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $real_bass_note_tracker_2_size {size $real_bass_note_tracker_2}}
-               {set $mp.endcache $mp.end} ; cache note end time
+               {set $dx_last_note_ended_real_bass $mp.end} ; cache note end time
             }
          }
       }
@@ -466,7 +467,7 @@
       {unless $first_keys_gem_tracked
          {set $first_keys_gem_tracked TRUE}
          {set $tracked_break_num_keys 0}
-         {set $mp.endcache 0} ; cache note end time
+         {set $dx_last_note_ended_keys 0} ; cache note end time
          {set $first_keys_gem_beat {int $mp.start}}
          {if {> $first_keys_gem_beat 16}
             {push_back $keys_note_tracker ("delay_0" 0 $first_keys_gem_beat)}
@@ -485,10 +486,10 @@
       {if {> $dx_final_note_keys $dx_final_note} {set $dx_final_note $dx_final_note_keys}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
-            {if {>= {- $mp.start $mp.endcache} 0}
+            {if {>= {- $mp.start $dx_last_note_ended_keys} 0} ;TODO: this logic does not work with overlapping notes!
                {push_back $keys_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $keys_note_tracker_2_size {size $keys_note_tracker_2}}
-               {set $mp.endcache $mp.end} ; cache note end time
+               {set $dx_last_note_ended_keys $mp.end} ; cache note end time
             }
          }
       }
@@ -551,7 +552,7 @@
       {unless $first_real_keys_gem_tracked
          {set $first_real_keys_gem_tracked TRUE}
          {set $tracked_break_num_real_keys 0}
-         {set $mp.endcache 0} ; cache note end time
+         {set $dx_last_note_ended_real_keys 0} ; cache note end time
          {set $first_real_keys_gem_beat {int $mp.start}}
          {if {> $first_real_keys_gem_beat 16}
             {push_back $real_keys_note_tracker ("delay_0" 0 $first_real_keys_gem_beat)}
@@ -570,10 +571,10 @@
       {if {> $dx_final_note_real_keys $dx_final_note} {set $dx_final_note $dx_final_note_real_keys}}
       {if $dx_perfects_indicator
          {if {&& {!= $mp.val 115} {!= $mp.val 116}}
-            {if {>= {- $mp.start $mp.endcache} 0}
+            {if {>= {- $mp.start $dx_last_note_ended_real_keys} 0} ;TODO: this logic does not work with overlapping notes!
                {push_back $real_keys_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $real_keys_note_tracker_2_size {size $real_keys_note_tracker_2}}
-               {set $mp.endcache $mp.end} ; cache note end time
+               {set $dx_last_note_ended_real_keys $mp.end} ; cache note end time
             }
          }
       }

--- a/_ark/dx/track/countdown/dx_countdown_midi_parsers.dta
+++ b/_ark/dx/track/countdown/dx_countdown_midi_parsers.dta
@@ -525,7 +525,7 @@
             ;}
 
             ; If this note starts a new batch
-            {if {!= $mp.start [dx_batch_start_beat_keys]}
+            {if {> {- $mp.start [dx_batch_start_beat_keys]}}
                ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "new start time, process batch of " {size [batch_notes_keys]} " notes"}}}
                
                ; Process previous batch (if any)
@@ -707,116 +707,116 @@
       {set $dx_final_note_real_keys {int $mp.end}}
       {if {> $dx_final_note_real_keys $dx_final_note} {set $dx_final_note $dx_final_note_real_keys}}
       {if $dx_perfects_indicator
-         ;Thanks ChatGPT
+         ;Thanks again ChatGPT
          ; Parse the 25-note range (limited by the allowed_notes attribute) 
          {if {&& {!= $mp.val 115} {!= $mp.val 116}}
-            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "starting parsing note"}}}
+            {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "starting parsing note"}}}
             ;{if {<= $real_keys_note_tracker_2_size 4000}
-            ;   ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint $real_keys_note_tracker_2_size "," {* {beat_to_seconds $mp.start} 1000} "," {* {beat_to_seconds $mp.end} 1000} "," $mp.start "," $mp.end "," [dx_batch_start_beat_real_keys] "," $mp.length "," $mp.prev_start "," $mp.prev_end "," $mp.data "," $mp.val }}}
+            ;   {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint $real_keys_note_tracker_2_size "," {* {beat_to_seconds $mp.start} 1000} "," {* {beat_to_seconds $mp.end} 1000} "," $mp.start "," $mp.end "," [dx_batch_start_beat_real_keys] "," $mp.length "," $mp.prev_start "," $mp.prev_end "," $mp.data "," $mp.val }}}
             ;}
 
             ; If this note starts a new batch
-            {if {!= $mp.start [dx_batch_start_beat_real_keys]}
-               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "new start time, process batch of " {size [batch_notes_real_keys]} " notes"}}}
+            {if {> {- $mp.start [dx_batch_start_beat_real_keys]} 0.02} ;changed from an equality check; fix for ever so slightly desynchronised notes, eg. https://rhythmverse.co/songfile/61304c77b01252.88654892
+               {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "new start time, process batch of " {size [batch_notes_real_keys]} " notes"}}}
                
                ; Process previous batch (if any)
                {if {> {size [batch_notes_real_keys]} 0}
                   {set [diff_end_found_real_keys] FALSE}
                   {if {> {size [batch_notes_real_keys]} 1}
-                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_real_keys] 0} 1} }}}
+                     {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_real_keys] 0} 1} }}}
                      {set $first_end {elem {elem [batch_notes_real_keys] 0} 1}}
                      {foreach $n [batch_notes_real_keys] 
-                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
+                        {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
                         {if {!= {elem $n 1} $first_end}
                            {set [diff_end_found_real_keys] TRUE}
                         }
                      }
-                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[diff_end_found_real_keys] = " [diff_end_found_real_keys]}}}
+                     {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "[diff_end_found_real_keys] = " [diff_end_found_real_keys]}}}
                   }
 
                   ; Push all notes if there's a differing end
                   {if_else {== [diff_end_found_real_keys] TRUE}
                      {foreach $n [batch_notes_real_keys] {do
-                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
+                        {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
                         {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
                      }}
                      {do
                         {set $n {elem [batch_notes_real_keys] 0}}
-                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
+                        {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
                         {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
                      }
                   }
                   
                   {set $real_keys_note_tracker_2_size {size $real_keys_note_tracker_2}}
-                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $real_keys_note_tracker_2_size = " $real_keys_note_tracker_2_size}}}
+                  {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "set $real_keys_note_tracker_2_size = " $real_keys_note_tracker_2_size}}}
                }
 
                ; Start new batch
-               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set [dx_batch_start_beat_real_keys] to " $mp.start}}}
+               {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "set [dx_batch_start_beat_real_keys] to " $mp.start}}}
                {set [dx_batch_start_beat_real_keys] $mp.start}
-               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[dx_batch_start_beat_real_keys] = " [dx_batch_start_beat_real_keys] ", set [batch_notes_real_keys] to empty array"}}}
+               {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "[dx_batch_start_beat_real_keys] = " [dx_batch_start_beat_real_keys] ", set [batch_notes_real_keys] to empty array"}}}
                {set [batch_notes_real_keys] {array ()}} ; Clear batch
             }
 
-            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "push back $dx_real_keys_note to [batch_notes_real_keys]"}}}
+            {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "push back $dx_real_keys_note to [batch_notes_real_keys]"}}}
             {set [dx_do_add_note_real_keys] TRUE}
             {if {> {size [batch_notes_real_keys]} 0}
                {foreach $n [batch_notes_real_keys]
-                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Checking for no matching note val " {elem $n 2}}}}
+                  {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "Checking for no matching note val " {elem $n 2}}}}
                   {if {== {elem $n 2} $mp.val}
-                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Second+ note with same start-time and val, skipping!"}}}
+                     {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "Second+ note with same start-time and val, skipping!"}}}
                      {set [dx_do_add_note_real_keys] FALSE}
                   }
                }
             }
             {if {== [dx_do_add_note_real_keys] TRUE} 
                {set $dx_real_keys_note {array ($mp.start $mp.end $mp.val)}}
-               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "$dx_real_keys_note = " $dx_real_keys_note}}}
+               {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "$dx_real_keys_note = " $dx_real_keys_note}}}
                {push_back [batch_notes_real_keys] $dx_real_keys_note}
             }
-            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys] = " [batch_notes_real_keys]}}}
-            ;{if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys].0 = " {elem [batch_notes_real_keys] 0}}}}}
-            ;{if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys].0.0 = " {elem {elem [batch_notes_real_keys] 0} 0}}}}}
-            ;{if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys].0.1 = " {elem {elem [batch_notes_real_keys] 0} 1}}}}}
+            {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "[batch_notes_real_keys] = " [batch_notes_real_keys]}}}
+            {if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} {dx_log_writer countdown {sprint "[batch_notes_real_keys].0 = " {elem [batch_notes_real_keys] 0}}}}}
+            {if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} {dx_log_writer countdown {sprint "[batch_notes_real_keys].0.0 = " {elem {elem [batch_notes_real_keys] 0} 0}}}}}
+            {if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} {dx_log_writer countdown {sprint "[batch_notes_real_keys].0.1 = " {elem {elem [batch_notes_real_keys] 0} 1}}}}}
             
-            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Currently " {size [batch_notes_real_keys]} " notes in cache"}}}
-            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "finished parsing note"}}}
+            {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "Currently " {size [batch_notes_real_keys]} " notes in cache"}}}
+            {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "finished parsing note"}}}
          }
       }
    )
    (term 
-      ;{dx_log_writer countdown {sprint "TERM"}}
+      {dx_log_writer countdown {sprint "TERM"}}
       {if $dx_perfects_indicator
          ; Add any hanging notes to the real_keys_note_tracker_2
          {if {> {size [batch_notes_real_keys]} 0}
             {set [diff_end_found_real_keys] FALSE}
             {if {> {size [batch_notes_real_keys]} 1}
-               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_real_keys] 0} 1} }}}
+               {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_real_keys] 0} 1} }}}
                {set $first_end {elem {elem [batch_notes_real_keys] 0} 1}}
                {foreach $n [batch_notes_real_keys] 
-                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
+                  {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
                   {if {!= {elem $n 1} $first_end}
                      {set [diff_end_found_real_keys] TRUE}
                   }
                }
-               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[diff_end_found_real_keys] = " [diff_end_found_real_keys]}}}
+               {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "[diff_end_found_real_keys] = " [diff_end_found_real_keys]}}}
             }
 
             ; Push all notes if there's a differing end
             {if_else {== [diff_end_found_real_keys] TRUE}
                {foreach $n [batch_notes_real_keys] {do
-                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
+                  {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
                   {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
                }}
                {do
                   {set $n {elem [batch_notes_real_keys] 0}}
-                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
+                  {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
                   {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
                }
             }
             
             {set $real_keys_note_tracker_2_size {size $real_keys_note_tracker_2}}
-            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $real_keys_note_tracker_2_size = " $real_keys_note_tracker_2_size}}}
+            {if {< {beat_to_seconds $mp.start} 60} {dx_log_writer countdown {sprint "set $real_keys_note_tracker_2_size = " $real_keys_note_tracker_2_size}}}
          }
       }
    )

--- a/_ark/dx/track/countdown/dx_countdown_midi_parsers.dta
+++ b/_ark/dx/track/countdown/dx_countdown_midi_parsers.dta
@@ -17,7 +17,7 @@
          {set $first_guitar_gem_tracked TRUE}
          {set $tracked_break_num_guitar 0}
          {set $first_guitar_gem_beat {int $mp.start}}
-         {set $dx_last_note_ended_guitar 0} ; cache note end time
+         {set $dx_last_note_started_guitar 0} ; cache note start time
          {if {> $first_guitar_gem_beat 16}
             {push_back $guitar_note_tracker ("delay_0" 0 $first_guitar_gem_beat)}
             {set $guitar_note_tracker {array $guitar_note_tracker}}
@@ -35,10 +35,10 @@
       {if {> $dx_final_note_guitar $dx_final_note} {set $dx_final_note $dx_final_note_guitar}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
-            {if {>= {- $mp.start $dx_last_note_ended_guitar} 0}
+            {if {> {- $mp.start $dx_last_note_started_guitar} 0}
                {push_back $guitar_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $guitar_note_tracker_2_size {size $guitar_note_tracker_2}}
-               {set $dx_last_note_ended_guitar $mp.end} ; cache note end time
+               {set $dx_last_note_started_guitar $mp.start} ; cache note start time
             }
          }
       }
@@ -101,7 +101,7 @@
       {unless $first_real_guitar_gem_tracked
          {set $first_real_guitar_gem_tracked TRUE}
          {set $tracked_break_num_real_guitar 0}
-         {set $dx_last_note_ended_real_guitar 0} ; cache note end time
+         {set $dx_last_note_started_real_guitar 0} ; cache note start time
          {set $first_real_guitar_gem_beat {int $mp.start}}
          {if {> $first_real_guitar_gem_beat 16}
             {push_back $real_guitar_note_tracker ("delay_0" 0 $first_real_guitar_gem_beat)}
@@ -120,10 +120,10 @@
       {if {> $dx_final_note_real_guitar $dx_final_note} {set $dx_final_note $dx_final_note_real_guitar}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100} {== $mp.val 101}}
-            {if {>= {- $mp.start $dx_last_note_ended_real_guitar} 0}
+            {if {> {- $mp.start $dx_last_note_started_real_guitar} 0}
                {push_back $real_guitar_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $real_guitar_note_tracker_2_size {size $real_guitar_note_tracker_2}}
-               {set $dx_last_note_ended_real_guitar $mp.end} ; cache note end time
+               {set $dx_last_note_started_real_guitar $mp.start} ; cache note start time
             }
          }
       }
@@ -208,13 +208,23 @@
    (mp.up FALSE)
    (idle)
    (allowed_notes
+      #ifdef RB3E
+      {if_else {modifier_mgr is_modifier_active mod_double_bass}
+         (24 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 95 96 97 98 99 100 103)
+         (24 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 96 97 98 99 100 103)
+      }
+      #else
       (24 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 96 97 98 99 100 103)
+      #endif
    )
    (midi
       {unless $first_drum_gem_tracked
          {set $first_drum_gem_tracked TRUE}
+         {set $dx_capture_drum TRUE}
          {set $tracked_break_num_drum 0}
          {set $first_drum_gem_beat {int $mp.start}}
+         {set $dx_last_kick_ended 0}
+         {set $dx_last_note_started_drum 0} ; cache note end time
          {if {> $first_drum_gem_beat 16}
             {push_back $drum_note_tracker ("delay_0" 0 $first_drum_gem_beat)}
             {set $drum_note_tracker {array $drum_note_tracker}}
@@ -231,9 +241,27 @@
       {set $dx_final_note_drum {int $mp.end}}
       {if {> $dx_final_note_drum $dx_final_note} {set $dx_final_note $dx_final_note_drum}}
       {if $dx_perfects_indicator
-         {if {|| {== $mp.val 95} {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
-            {push_back $drum_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
-            {set $drum_note_tracker_2_size {size $drum_note_tracker_2}}
+         {if {|| #ifdef RB3E {&& {== $mp.val 95} {modifier_mgr is_modifier_active mod_double_bass}} #endif {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
+            {if {< {- $mp.start $dx_last_note_started_drum} 0}
+               {set $dx_capture_drum FALSE} ;will be triggered the first time the parser jumps to the beginning after having completed the mid
+            }
+            {if {&& $dx_capture_drum {>= {- $mp.end $dx_last_note_started_drum} 0}}
+               {unless {&& {|| {== $mp.val 95} {== $mp.val 96}} {< {- $mp.start $dx_last_kick_ended} 0}} ;workaround for RB3E 2x kick overlapping notes which are dropped by the RB3 engine
+                  {push_back $drum_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
+                  {set $drum_note_tracker_2_size {size $drum_note_tracker_2}} 
+               
+                  ;{if {== $drum_note_tracker_2_size 1}
+                  ;   ;{dx_log_writer countdown {sprint "NoteID,Time,End,dx_last_note_started_drum,mp.start,mp.end,mp.length,mp.prev_start,mp.prev_end,mp.data,mp.val"}}
+                  ;}
+                  ;{if {<= $drum_note_tracker_2_size 4000}
+                  ;   ;{dx_log_writer countdown {sprint $drum_note_tracker_2_size "," {* {beat_to_seconds $mp.start} 1000} "," {* {beat_to_seconds $mp.end} 1000} "," $dx_last_note_started_drum "," $mp.start "," $mp.end "," $mp.length "," $mp.prev_start "," $mp.prev_end "," $mp.data "," $mp.val }}
+                  ;}
+                  {set $dx_last_note_started_drum {int $mp.start}}
+                  {if {|| {== $mp.val 95} {== $mp.val 96}}
+                     {set $dx_last_kick_ended $mp.end}
+                  }
+               }
+            }
          }
       }
       {set $dx_final_note_real_drum $dx_final_note_drum}
@@ -298,7 +326,7 @@
       {unless $first_bass_gem_tracked
          {set $first_bass_gem_tracked TRUE}
          {set $tracked_break_num_bass 0}
-         {set $dx_last_note_ended_bass 0} ; cache note end time
+         {set $dx_last_note_started_bass 0} ; cache note start time
          {set $first_bass_gem_beat {int $mp.start}}
          {if {> $first_bass_gem_beat 16}
             {push_back $bass_note_tracker ("delay_0" 0 $first_bass_gem_beat)}
@@ -317,10 +345,10 @@
       {if {> $dx_final_note_bass $dx_final_note} {set $dx_final_note $dx_final_note_bass}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
-            {if {>= {- $mp.start $dx_last_note_ended_bass} 0}
+            {if {> {- $mp.start $dx_last_note_started_bass} 0}
                {push_back $bass_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $bass_note_tracker_2_size {size $bass_note_tracker_2}}
-               {set $dx_last_note_ended_bass $mp.end} ; cache note end time
+               {set $dx_last_note_started_bass $mp.start} ; cache note start time
             }
          }
       }
@@ -382,7 +410,7 @@
       {unless $first_real_bass_gem_tracked
          {set $first_real_bass_gem_tracked TRUE}
          {set $tracked_break_num_real_bass 0}
-         {set $dx_last_note_ended_real_bass 0} ; cache note end time
+         {set $dx_last_note_started_real_bass 0} ; cache note start time
          {set $first_real_bass_gem_beat {int $mp.start}}
          {if {> $first_real_bass_gem_beat 16}
             {push_back $real_bass_note_tracker ("delay_0" 0 $first_real_bass_gem_beat)}
@@ -401,10 +429,10 @@
       {if {> $dx_final_note_real_bass $dx_final_note} {set $dx_final_note $dx_final_note_real_bass}}
       {if $dx_perfects_indicator
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100} {== $mp.val 101}}
-            {if {>= {- $mp.start $dx_last_note_ended_real_bass} 0}
+            {if {> {- $mp.start $dx_last_note_started_real_bass} 0}
                {push_back $real_bass_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
                {set $real_bass_note_tracker_2_size {size $real_bass_note_tracker_2}}
-               {set $dx_last_note_ended_real_bass $mp.end} ; cache note end time
+               {set $dx_last_note_started_real_bass $mp.start} ; cache note start time
             }
          }
       }
@@ -466,8 +494,11 @@
       {$this rt_compute_space}
       {unless $first_keys_gem_tracked
          {set $first_keys_gem_tracked TRUE}
+         {set $first_note_done_keys FALSE}
+         ;{dx_log_writer countdown {sprint "NoteID,Time,End,mp.start,mp.end,dx_batch_start_tick_keys,mp.length,mp.prev_start,mp.prev_end,mp.data,mp.val"}}
          {set $tracked_break_num_keys 0}
-         {set $dx_last_note_ended_keys 0} ; cache note end time
+         {set [dx_batch_start_beat_keys] -1}
+         {set [batch_notes_keys] {array ()}}
          {set $first_keys_gem_beat {int $mp.start}}
          {if {> $first_keys_gem_beat 16}
             {push_back $keys_note_tracker ("delay_0" 0 $first_keys_gem_beat)}
@@ -485,12 +516,116 @@
       {set $dx_final_note_keys {int $mp.end}}
       {if {> $dx_final_note_keys $dx_final_note} {set $dx_final_note $dx_final_note_keys}}
       {if $dx_perfects_indicator
+         ;Thanks ChatGPT
+         ; Only parse KEYS notes 96–100
          {if {|| {== $mp.val 96} {== $mp.val 97} {== $mp.val 98} {== $mp.val 99} {== $mp.val 100}}
-            {if {>= {- $mp.start $dx_last_note_ended_keys} 0} ;TODO: this logic does not work with overlapping notes!
-               {push_back $keys_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
-               {set $keys_note_tracker_2_size {size $keys_note_tracker_2}}
-               {set $dx_last_note_ended_keys $mp.end} ; cache note end time
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "starting parsing note"}}}
+            ;{if {<= $keys_note_tracker_2_size 4000}
+            ;   ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint $keys_note_tracker_2_size "," {* {beat_to_seconds $mp.start} 1000} "," {* {beat_to_seconds $mp.end} 1000} "," $mp.start "," $mp.end "," [dx_batch_start_beat_keys] "," $mp.length "," $mp.prev_start "," $mp.prev_end "," $mp.data "," $mp.val }}}
+            ;}
+
+            ; If this note starts a new batch
+            {if {!= $mp.start [dx_batch_start_beat_keys]}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "new start time, process batch of " {size [batch_notes_keys]} " notes"}}}
+               
+               ; Process previous batch (if any)
+               {if {> {size [batch_notes_keys]} 0}
+                  {set [diff_end_found_keys] FALSE}
+                  {if {> {size [batch_notes_keys]} 1}
+                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_keys] 0} 1} }}}
+                     {set $first_end {elem {elem [batch_notes_keys] 0} 1}}
+                     {foreach $n [batch_notes_keys] 
+                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
+                        {if {!= {elem $n 1} $first_end}
+                           {set [diff_end_found_keys] TRUE}
+                        }
+                     }
+                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[diff_end_found_keys] = " [diff_end_found_keys]}}}
+                  }
+
+                  ; Push all notes if there's a differing end
+                  {if_else {== [diff_end_found_keys] TRUE}
+                     {foreach $n [batch_notes_keys] {do
+                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
+                        {push_back $keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+                     }}
+                     {do
+                        {set $n {elem [batch_notes_keys] 0}}
+                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
+                        {push_back $keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+                     }
+                  }
+                  
+                  {set $keys_note_tracker_2_size {size $keys_note_tracker_2}}
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $keys_note_tracker_2_size = " $keys_note_tracker_2_size}}}
+               }
+
+               ; Start new batch
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set [dx_batch_start_beat_keys] to " $mp.start}}}
+               {set [dx_batch_start_beat_keys] $mp.start}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[dx_batch_start_beat_keys] = " [dx_batch_start_beat_keys] ", set [batch_notes_keys] to empty array"}}}
+               {set [batch_notes_keys] {array ()}} ; Clear batch
             }
+
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "push back $dx_keys_note to [batch_notes_keys]"}}}
+            {set [dx_do_add_note_keys] TRUE}
+            {if {> {size [batch_notes_keys]} 0}
+               {foreach $n [batch_notes_keys]
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Checking for no matching note val " {elem $n 2}}}}
+                  {if {== {elem $n 2} $mp.val}
+                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Second+ note with same start-time and val, skipping!"}}}
+                     {set [dx_do_add_note_keys] FALSE}
+                  }
+               }
+            }
+            {if {== [dx_do_add_note_keys] TRUE} 
+               {set $dx_keys_note {array ($mp.start $mp.end $mp.val)}}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "$dx_keys_note = " $dx_keys_note}}}
+               {push_back [batch_notes_keys] $dx_keys_note}
+            }
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[batch_notes_keys] = " [batch_notes_keys]}}}
+            ;{if {&& {> {size [batch_notes_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_keys].0 = " {elem [batch_notes_keys] 0}}}}}
+            ;{if {&& {> {size [batch_notes_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_keys].0.0 = " {elem {elem [batch_notes_keys] 0} 0}}}}}
+            ;{if {&& {> {size [batch_notes_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_keys].0.1 = " {elem {elem [batch_notes_keys] 0} 1}}}}}
+            
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Currently " {size [batch_notes_keys]} " notes in cache"}}}
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "finished parsing note"}}}
+         }
+      }
+   )
+   (term 
+      ;{dx_log_writer countdown {sprint "TERM"}}
+      {if $dx_perfects_indicator
+         ; Add any hanging notes to the keys_note_tracker_2
+         {if {> {size [batch_notes_keys]} 0}
+            {set [diff_end_found_keys] FALSE}
+            {if {> {size [batch_notes_keys]} 1}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_keys] 0} 1} }}}
+               {set $first_end {elem {elem [batch_notes_keys] 0} 1}}
+               {foreach $n [batch_notes_keys] 
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
+                  {if {!= {elem $n 1} $first_end}
+                     {set [diff_end_found_keys] TRUE}
+                  }
+               }
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[diff_end_found_keys] = " [diff_end_found_keys]}}}
+            }
+
+            ; Push all notes if there's a differing end
+            {if_else {== [diff_end_found_keys] TRUE}
+               {foreach $n [batch_notes_keys] {do
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
+                  {push_back $keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+               }}
+               {do
+                  {set $n {elem [batch_notes_keys] 0}}
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
+                  {push_back $keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+               }
+            }
+            
+            {set $keys_note_tracker_2_size {size $keys_note_tracker_2}}
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $keys_note_tracker_2_size = " $keys_note_tracker_2_size}}}
          }
       }
    )
@@ -551,8 +686,10 @@
       {$this rt_compute_space}
       {unless $first_real_keys_gem_tracked
          {set $first_real_keys_gem_tracked TRUE}
+         {set [dx_batch_start_beat_real_keys] -1}
+         {set [batch_notes_real_keys] {array ()}}
          {set $tracked_break_num_real_keys 0}
-         {set $dx_last_note_ended_real_keys 0} ; cache note end time
+         {set $dx_last_note_started_real_keys 0} ; cache note start time
          {set $first_real_keys_gem_beat {int $mp.start}}
          {if {> $first_real_keys_gem_beat 16}
             {push_back $real_keys_note_tracker ("delay_0" 0 $first_real_keys_gem_beat)}
@@ -570,12 +707,116 @@
       {set $dx_final_note_real_keys {int $mp.end}}
       {if {> $dx_final_note_real_keys $dx_final_note} {set $dx_final_note $dx_final_note_real_keys}}
       {if $dx_perfects_indicator
+         ;Thanks ChatGPT
+         ; Parse the 25-note range (limited by the allowed_notes attribute) 
          {if {&& {!= $mp.val 115} {!= $mp.val 116}}
-            {if {>= {- $mp.start $dx_last_note_ended_real_keys} 0} ;TODO: this logic does not work with overlapping notes!
-               {push_back $real_keys_note_tracker_2 {* {beat_to_seconds $mp.start} 1000}}
-               {set $real_keys_note_tracker_2_size {size $real_keys_note_tracker_2}}
-               {set $dx_last_note_ended_real_keys $mp.end} ; cache note end time
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "starting parsing note"}}}
+            ;{if {<= $real_keys_note_tracker_2_size 4000}
+            ;   ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint $real_keys_note_tracker_2_size "," {* {beat_to_seconds $mp.start} 1000} "," {* {beat_to_seconds $mp.end} 1000} "," $mp.start "," $mp.end "," [dx_batch_start_beat_real_keys] "," $mp.length "," $mp.prev_start "," $mp.prev_end "," $mp.data "," $mp.val }}}
+            ;}
+
+            ; If this note starts a new batch
+            {if {!= $mp.start [dx_batch_start_beat_real_keys]}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "new start time, process batch of " {size [batch_notes_real_keys]} " notes"}}}
+               
+               ; Process previous batch (if any)
+               {if {> {size [batch_notes_real_keys]} 0}
+                  {set [diff_end_found_real_keys] FALSE}
+                  {if {> {size [batch_notes_real_keys]} 1}
+                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_real_keys] 0} 1} }}}
+                     {set $first_end {elem {elem [batch_notes_real_keys] 0} 1}}
+                     {foreach $n [batch_notes_real_keys] 
+                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
+                        {if {!= {elem $n 1} $first_end}
+                           {set [diff_end_found_real_keys] TRUE}
+                        }
+                     }
+                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[diff_end_found_real_keys] = " [diff_end_found_real_keys]}}}
+                  }
+
+                  ; Push all notes if there's a differing end
+                  {if_else {== [diff_end_found_real_keys] TRUE}
+                     {foreach $n [batch_notes_real_keys] {do
+                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
+                        {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+                     }}
+                     {do
+                        {set $n {elem [batch_notes_real_keys] 0}}
+                        ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
+                        {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+                     }
+                  }
+                  
+                  {set $real_keys_note_tracker_2_size {size $real_keys_note_tracker_2}}
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $real_keys_note_tracker_2_size = " $real_keys_note_tracker_2_size}}}
+               }
+
+               ; Start new batch
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set [dx_batch_start_beat_real_keys] to " $mp.start}}}
+               {set [dx_batch_start_beat_real_keys] $mp.start}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[dx_batch_start_beat_real_keys] = " [dx_batch_start_beat_real_keys] ", set [batch_notes_real_keys] to empty array"}}}
+               {set [batch_notes_real_keys] {array ()}} ; Clear batch
             }
+
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "push back $dx_real_keys_note to [batch_notes_real_keys]"}}}
+            {set [dx_do_add_note_real_keys] TRUE}
+            {if {> {size [batch_notes_real_keys]} 0}
+               {foreach $n [batch_notes_real_keys]
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Checking for no matching note val " {elem $n 2}}}}
+                  {if {== {elem $n 2} $mp.val}
+                     ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Second+ note with same start-time and val, skipping!"}}}
+                     {set [dx_do_add_note_real_keys] FALSE}
+                  }
+               }
+            }
+            {if {== [dx_do_add_note_real_keys] TRUE} 
+               {set $dx_real_keys_note {array ($mp.start $mp.end $mp.val)}}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "$dx_real_keys_note = " $dx_real_keys_note}}}
+               {push_back [batch_notes_real_keys] $dx_real_keys_note}
+            }
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys] = " [batch_notes_real_keys]}}}
+            ;{if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys].0 = " {elem [batch_notes_real_keys] 0}}}}}
+            ;{if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys].0.0 = " {elem {elem [batch_notes_real_keys] 0} 0}}}}}
+            ;{if {&& {> {size [batch_notes_real_keys]} 0} {< {* {beat_to_seconds $mp.start} 1000} 48000} ;{dx_log_writer countdown {sprint "[batch_notes_real_keys].0.1 = " {elem {elem [batch_notes_real_keys] 0} 1}}}}}
+            
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "Currently " {size [batch_notes_real_keys]} " notes in cache"}}}
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "finished parsing note"}}}
+         }
+      }
+   )
+   (term 
+      ;{dx_log_writer countdown {sprint "TERM"}}
+      {if $dx_perfects_indicator
+         ; Add any hanging notes to the real_keys_note_tracker_2
+         {if {> {size [batch_notes_real_keys]} 0}
+            {set [diff_end_found_real_keys] FALSE}
+            {if {> {size [batch_notes_real_keys]} 1}
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $first_end to " {elem {elem [batch_notes_real_keys] 0} 1} }}}
+               {set $first_end {elem {elem [batch_notes_real_keys] 0} 1}}
+               {foreach $n [batch_notes_real_keys] 
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "checking note " $n " for different end time, using value " {elem $n 1}}}}
+                  {if {!= {elem $n 1} $first_end}
+                     {set [diff_end_found_real_keys] TRUE}
+                  }
+               }
+               ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "[diff_end_found_real_keys] = " [diff_end_found_real_keys]}}}
+            }
+
+            ; Push all notes if there's a differing end
+            {if_else {== [diff_end_found_real_keys] TRUE}
+               {foreach $n [batch_notes_real_keys] {do
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back note with time " {elem $n 0}}}}
+                  {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+               }}
+               {do
+                  {set $n {elem [batch_notes_real_keys] 0}}
+                  ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "pushing back singular note with time " {elem $n 0}}}}
+                  {push_back $real_keys_note_tracker_2 {* {beat_to_seconds {elem $n 0}} 1000}}
+               }
+            }
+            
+            {set $real_keys_note_tracker_2_size {size $real_keys_note_tracker_2}}
+            ;{if {< {beat_to_seconds $mp.start} 60} ;{dx_log_writer countdown {sprint "set $real_keys_note_tracker_2_size = " $real_keys_note_tracker_2_size}}}
          }
       }
    )


### PR DESCRIPTION
I've reworked parts of the MidiParsers responsible for generating the note trackers used for the judgments, in order to better handle edge cases which can cause the failsafe to be triggered, rendering all judgments invalid.
General:

- Added save/load support for the Judgment Debug toggle
- Separated $mp.endcache variables into separate variables per instrument in order to avoid a potential race condition
- Added debug display when tracker and game note counts don't match up, causing invalid judgments
- Added a debug message which will show in logs when a chart has invalid judgments

Guitar/bass:

- now tracking against the start of a note, since that is what is stored into the tracker

Drums - 

- Added protection against second parsing of chart (I suspect this happens when an upgrade overrides the original file)
- Added support for RB3E 2x bass modifier (fixes #1079)
- Added protection against notes in either bass lane overlapping in 2x mode

Keys - 

- Complete rework of parsing logic, with a little (a lot) of help from ChatGPT to figure out how to translate the behaviour of the game into logic that can be executed in DTA to match
- Handles broken chords properly according to the game counters
- Logic also applied to Pro Keys
- Small (0.02 beats) window given for desynchronised notes which are converted to proper chords by the game - discovered on custom of At Doom's Gate (https://rhythmverse.co/songfile/61304c77b01252.88654892)
- Note that a lot of the debug statements I used to help ensure the functionality have been left in, but commented out for performance

Tested against all songs listed in issue #1000 on respective instruments, along with Beast and the Harlot (for 2x drums), Pull Me Under and Highway Star (keys/pro, as provided in upgrades built into DX). Only tested on Xbox 360. Likely to have slightly increased memory usage, due to the increased number of variables used (separating $mp.endcache, keys logic).