### PR TITLE
custom lyric highlight color (overshell rewrite exclusive)

### DIFF
--- a/_ark/dx/locale/dx_locale_updates.dta
+++ b/_ark/dx/locale/dx_locale_updates.dta
@@ -712,6 +712,8 @@
 (os_lyric_display_off_desc "Lyrics are hidden")
 (os_lyric_display_on "Lyric Display: ON")
 (os_lyric_display_on_desc "Lyrics are shown when there is no vocals player, similar to Clone Hero and YARG")
+(os_lyric_highlight_color "Lyric Highlight Color")
+(os_lyric_highlight_color_desc "Change the color of the sang syllables in the lyrics display")
 (os_minus1 "-1")
 (os_minus10 "-10")
 (os_minus25 "-25")

--- a/_ark/dx/overshell/dx_color_states.dta
+++ b/_ark/dx/overshell/dx_color_states.dta
@@ -513,6 +513,11 @@
          {set $dx_set_ui_rgb_g $dx_track_streak_g}
          {set $dx_set_ui_rgb_b $dx_track_streak_b}
       )
+      (lyric_highlight
+         {set $dx_set_ui_rgb_r $dx_lyric_highlight_r}
+         {set $dx_set_ui_rgb_g $dx_lyric_highlight_g}
+         {set $dx_set_ui_rgb_b $dx_lyric_highlight_b}
+      )
       kDataUnhandled
    }
 )
@@ -523,6 +528,7 @@
       (highway_overdrive_text {set $dx_set_ui_rgb_r 1})
       (highway_username_text {set $dx_set_ui_rgb_r 1})
       (highway_streak_text {set $dx_set_ui_rgb_r 1})
+      (lyric_highlight {set $dx_set_ui_rgb_r 0})
       1
    }
    {switch $dx_set_ui_rgb_tracked_ui
@@ -530,6 +536,7 @@
       (highway_overdrive_text {set $dx_set_ui_rgb_g 1})
       (highway_username_text {set $dx_set_ui_rgb_g 1})
       (highway_streak_text {set $dx_set_ui_rgb_g 1})
+      (lyric_highlight {set $dx_set_ui_rgb_g 0.98})
       1
    }
    {switch $dx_set_ui_rgb_tracked_ui
@@ -537,6 +544,7 @@
       (highway_overdrive_text {set $dx_set_ui_rgb_b 1})
       (highway_username_text {set $dx_set_ui_rgb_b 1})
       (highway_streak_text {set $dx_set_ui_rgb_b 1})
+      (lyric_highlight {set $dx_set_ui_rgb_b 0.68})
       1
    }
 )
@@ -584,6 +592,16 @@
                {if {!= {$player instrument} vocals}
                   {dx_track_label_streak dx_track_label_streak $dx_track_streak_size $dx_track_streak_font $dx_track_streak_alignment $dx_track_streak_kerning {{$player get_user} get_slot_num} $dx_track_streak_x $dx_track_streak_y $dx_track_streak_r $dx_track_streak_g $dx_track_streak_b FALSE}
                }
+            }
+         }
+      )
+      (lyric_highlight
+         {set $dx_lyric_highlight_r $dx_set_ui_rgb_r}
+         {set $dx_lyric_highlight_g $dx_set_ui_rgb_g}
+         {set $dx_lyric_highlight_b $dx_set_ui_rgb_b}
+         {if {$this in_game}
+            {if {coop_track_panel exists lyric_highlight.color}
+               {{coop_track_panel find lyric_highlight.color} set color {pack_color $dx_lyric_highlight_r $dx_lyric_highlight_g $dx_lyric_highlight_b}}
             }
          }
       )
@@ -704,6 +722,7 @@
                   (highway_overdrive_text {dx_state dxState_TrackHighwayOverdrive})
                   (highway_username_text {dx_state dxState_TrackHighwayUsername})
                   (highway_streak_text {dx_state dxState_TrackHighwayStreak})
+                  (lyric_highlight {dx_state dxState_InGameHUD})
                }
             }
          )

--- a/_ark/dx/overshell/dx_hud_states.dta
+++ b/_ark/dx/overshell/dx_hud_states.dta
@@ -3,6 +3,7 @@
       (view
          os_mtv
          {if_else $dx_lyric_display_enabled os_lyric_display_on os_lyric_display_off}
+         os_lyric_highlight_color
          {switch $dx_crowd_meter_state
             (dx_on os_vis_on)
             (dx_off os_vis_off)
@@ -35,6 +36,10 @@
          (os_practice_hud {dx_state dxState_ScreenElements_Practice})
          (os_mtv {dx_state dxState_MTVElements})
          (os_lyric_display {set $dx_lyric_display_enabled {! $dx_lyric_display_enabled}})
+         (os_lyric_highlight_color
+            {set $dx_set_ui_rgb_tracked_ui lyric_highlight}
+            {dx_state dxState_rgbcolormenu}
+         )
          #define CROWD_METER_SELECT
          (
             {set $dx_crowd_meter_state

--- a/_ark/dx/read_write/dx_reader_macros.dta
+++ b/_ark/dx/read_write/dx_reader_macros.dta
@@ -579,6 +579,17 @@
          {elem {find $entry dx_lyric_display_enabled} 1}
       }
    }
+   {if {== {elem $entry 0} {basename dx_lyric_highlight_color}}
+      {set $dx_lyric_highlight_r
+         {elem {elem {find $entry dx_lyric_highlight_color} 1} 0}
+      }
+      {set $dx_lyric_highlight_g
+         {elem {elem {find $entry dx_lyric_highlight_color} 1} 1}
+      }
+      {set $dx_lyric_highlight_b
+         {elem {elem {find $entry dx_lyric_highlight_color} 1} 2}
+      }
+   }
    {if {== {elem $entry 0} {basename dx_crowd_meter_state}}
       {set $dx_crowd_meter_state
          {elem {find $entry dx_crowd_meter_state} 1}

--- a/_ark/dx/read_write/dx_writer_macros.dta
+++ b/_ark/dx/read_write/dx_writer_macros.dta
@@ -128,6 +128,7 @@
    {dx_setting_saver dx_settings dx_player_icons $dx_player_icons}
    {dx_setting_saver dx_settings dx_instrument_icons $dx_instrument_icons}
    {dx_setting_saver dx_settings dx_lyric_display_enabled $dx_lyric_display_enabled}
+   {dx_setting_saver dx_settings dx_lyric_highlight_color ($dx_lyric_highlight_r $dx_lyric_highlight_g $dx_lyric_highlight_b)}
    {dx_setting_saver dx_settings dx_crowd_meter_state $dx_crowd_meter_state}
    {dx_setting_saver dx_settings dx_score_meter_visibility $dx_score_meter_visibility}
    {dx_setting_saver dx_settings dx_gold_star_progress $dx_gold_star_progress}

--- a/_ark/dx/track/hud_ui/dx_hud_ui_funcs.dta
+++ b/_ark/dx/track/hud_ui/dx_hud_ui_funcs.dta
@@ -707,7 +707,7 @@
       {lyric_display.grp set_trans_parent draw_order.grp}
 
       {new UIColor lyric_highlight.color}
-      {lyric_highlight.color set color {pack_color 0 0.98 0.68}}
+      {lyric_highlight.color set color {pack_color $dx_lyric_highlight_r $dx_lyric_highlight_g $dx_lyric_highlight_b}}
       ;{new UIColor lyric_normal.color}
       ;{lyric_normal.color set color {pack_color 1 1 1}}
 

--- a/_ark/dx/ui/dx_ui_init.dta
+++ b/_ark/dx/ui/dx_ui_init.dta
@@ -719,6 +719,10 @@ DX_CURRENT_SONG_CLEAR
 {set $dx_score_meter_visibility TRUE}
 {set $dx_fail_flash TRUE}
 
+{set $dx_lyric_highlight_r 0.0}
+{set $dx_lyric_highlight_g 0.98}
+{set $dx_lyric_highlight_b 0.69}
+
 
 ;currentsong formatting defauts
 {set $dx_mtv_visibility always}


### PR DESCRIPTION
needs localization for `os_lyric_highlight_color` and `os_lyric_highlight_color_desc`