### PR TITLE
hide gold stars on track panel exit

### DIFF
--- a/_ark/dx/track/track/dx_track_panel_handles.dta
+++ b/_ark/dx/track/track/dx_track_panel_handles.dta
@@ -1,6 +1,9 @@
 #define DX_TRACK_PANEL_HANDLES
 (
    (dx_track_panel_exit ;this is really stupid but debug found out that the textures need to be put back to origin, deleted, and remade per enter
+      {if {exists gold_star_handler}
+         {gold_star_handler hide_stars}
+      }
       {unless {$this get dx_is_nohud}
          {{coop_track_panel find fcframe.tex} iterate_refs $ref {$ref set diffuse_tex streak_meter_plate.tex}} ;apply the fc texture to the ring material
          {{coop_track_panel find multframe.tex} iterate_refs $ref {$ref set diffuse_tex streak_meter_plate.tex}} ;apply the fc texture to the ring material


### PR DESCRIPTION
fixes this bug:
![image](https://github.com/user-attachments/assets/56eafcf6-81cc-436a-9039-c480eeb11120)
pr to overshell_rewrite because i can't boot the develop branch without deleting my dx_settings