### PR TITLE
read ace.dta from NAND on Dolphin

### DIFF
--- a/_ark/dx/overshell/dx_advanced_states.dta
+++ b/_ark/dx/overshell/dx_advanced_states.dta
@@ -386,10 +386,17 @@
       )
       #endif
       #ifdef HX_WII
+      #ifdef RB3E_EMULATOR
       #define DX_ACE_PATH
       (
-         {sprint "ace.dta"}
+         {sprint "nand/ace.dta"}
       )
+      #else
+      #define DX_ACE_PATH
+      (
+         {sprint "sd:/rb3/ace.dta"}
+      )
+      #endif
       #endif
       (view
          os_debug_mode


### PR DESCRIPTION
requires RB3Enhanced 83e4bb0 nightly