### PR TITLE
Jukebox Mode and Free Cam Fix

### DIFF
--- a/_ark/dx/overshell/dx_warning_states.dta
+++ b/_ark/dx/overshell/dx_warning_states.dta
@@ -357,10 +357,10 @@
          (overshell_continue
             {set $dx_dont_save_mod TRUE}
             {enable_modifier mod_auto_play}
-            ;{enable_modifier mod_nohud}
-            ;{enable_modifier mod_nopause}
+            {enable_modifier mod_nohud}
+            {enable_modifier mod_nopause}
             {enable_modifier mod_fakejuke}
-            ;{enable_modifier mod_dx_no_overdrive}
+            {enable_modifier mod_dx_no_overdrive}
             {set $dx_mtv_visibility default}
             {set $dx_mtv_line_bpm FALSE}
             ;{disable_modifier mod_drum_fills}

--- a/_ark/ui/overshell/slot_states.dta
+++ b/_ark/ui/overshell/slot_states.dta
@@ -2032,10 +2032,10 @@
       #ifdef RB3E
       {if {! {$this in_game}} {push_back $arr delete_cache}}
       #endif
-      {if_else {== {ui current_screen} song_select_screen}
-         {push_back $arr $dx_current_free_cam}
-         {push_back $arr os_screensaver}
+      {if {modifier_mgr is_modifier_active mod_auto_play}
+         {push_back $arr $dx_current_free_cam} ; dx - show autoplay settings when active
       }
+      {push_back $arr os_screensaver}
       {options_audio.lst set_data $arr}
    }
 )


### PR DESCRIPTION
This makes the interface hide again and the free camera option appears when autoplay or jukebox is activated