### PR TITLE
Make search cache store shortnames with parenthesis in them as strings

### DIFF
--- a/_ark/dx/ui/dx_search_funcs.dta
+++ b/_ark/dx/ui/dx_search_funcs.dta
@@ -110,10 +110,17 @@
         {music_library set_highlight_ix $searchcache_curdata FALSE}
         {do
             ($node {music_library get_highlighted_node})
+            ($shortname "blank")
+            ($shortname_str "blank")
             {if {== {$node get_node_type} kNodeSong}
                 ;{song_select_panel dx_authorpoll {$node get_token}}
                 ; Author finder is too slow
-                {push_back $searchcache_buf {array ({$node get_token} ({$node title} {dx_hyper_finder get_artist_from_sort_node $node}) $searchcache_curdata)}}
+                {set $shortname {$node get_token}}
+                {set $shortname_str {sprint $shortname}}
+                {if {|| {has_substr $shortname_str "("} {has_substr $shortname_str ")"}}
+                    {set $shortname $shortname_str}
+                }
+                {push_back $searchcache_buf {array ($shortname ({$node title} {dx_hyper_finder get_artist_from_sort_node $node}) $searchcache_curdata)}}
                 {+= $searchcache_count 1}
                 {if {>= {size $searchcache_buf} SONGS_PER_CACHE_PAGE}
                     {dx_generate_search_cache_flushbuffer}


### PR DESCRIPTION
Remember: bad customs are still bad.