### PR TITLE
Update forbidden shortnames

### DIFF
--- a/_ark/dx/song_updates/metadata_updates.dta
+++ b/_ark/dx/song_updates/metadata_updates.dta
@@ -1069,11 +1069,11 @@
 (wearefamily (genre disco))
 
 ; Forbidden changes
-(highhopes_fnfestival (artist "Panic! at the Disco"))
+(highhopesfnf (artist "Panic! at the Disco"))
 (iwritesinsfnf (artist "Panic! at the Disco"))
 (lessthan (genre industrial))
 (marchofthepigsfnf (genre industrial))
-(thehandthat_fnf (genre industrial))
+(thehandthatfnf (genre industrial))
 
 ; Lost Rock Band DLC Changes
 (behindblueeyes_cover (covered_by "WaveGroup"))

--- a/_ark/dx/song_updates/songs_updates.dta
+++ b/_ark/dx/song_updates/songs_updates.dta
@@ -75863,7 +75863,7 @@
 (wearefamily
    (genre disco)
 )
-(highhopes_fnfestival
+(highhopesfnf
    (artist
       "Panic! at the Disco"
    )
@@ -75879,7 +75879,7 @@
 (marchofthepigsfnf
    (genre industrial)
 )
-(thehandthat_fnf
+(thehandthatfnf
    (genre industrial)
 )
 (stopandstare


### PR DESCRIPTION
The returning shortnames were standardized recently so I need to update the ones in the metadata updates to match